### PR TITLE
Make error messages easier to view

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -223,13 +223,23 @@ function Remove-Packages {
             Write-Host "Some packages could not be removed. Do not worry: your image will still work fine. This can happen if the package is permanent or has been superseded by a newer one."
             if ($erroredPackages.Count -gt 0)
             {
-                $erroredPackages
                 $ErrorMessageComparer = [ErroredPackageComparer]::new("ErrorMessage")
                 $erroredPackages.Sort($ErrorMessageComparer)
+
+                $previousErroredPackage = $erroredPackage[0]
+                $counter = 0
+                Write-Host ""
+                Write-Host "Failed to remove following packages due to reason '$($previousErroredPackage.ErrorMessage)':"
                 foreach ($erroredPackage in $erroredPackages) {
-                    Write-Host "Failed to remove Package $($erroredPackage.PackageName) due to $($erroredPackage.ErrorMessage)" -NoNewline
+                    if ($erroredPackage.ErrorMessage -ne $previousErroredPackage.ErrorMessage) {
+                        $counter = 0
+                        Write-Host ""
+                        Write-Host "Failed to remove following packages due to reason '$($erroredPackage.ErrorMessage)':"
+                    }
+                    $counter += 1
+                    Write-Host "  $counter) $($erroredPackage.PackageName)" -NoNewline
+                    $previousErroredPackage = $erroredPackage
                 }
-                #$erroredPackages
             }
         }
     } catch {

--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -220,26 +220,27 @@ function Remove-Packages {
         Write-Progress -Activity "Removing Packages" -Status "Ready" -Completed
         if ($failedCount -gt 0)
         {
-            Write-Host "Some packages could not be removed. Do not worry: your image will still work fine. This can happen if the package is permanent or has been superseded by a newer one."
+            Write-Host "$failedCount package(s) could not be removed. Your image will still work fine, however. Below is information on what packages failed to be removed and why."
             if ($erroredPackages.Count -gt 0)
             {
                 $ErrorMessageComparer = [ErroredPackageComparer]::new("ErrorMessage")
                 $erroredPackages.Sort($ErrorMessageComparer)
 
-                $previousErroredPackage = $erroredPackage[0]
+                $previousErroredPackage = $erroredPackages[0]
                 $counter = 0
                 Write-Host ""
-                Write-Host "Failed to remove following packages due to reason '$($previousErroredPackage.ErrorMessage)':"
+                Write-Host "- $($previousErroredPackage.ErrorMessage)"
                 foreach ($erroredPackage in $erroredPackages) {
                     if ($erroredPackage.ErrorMessage -ne $previousErroredPackage.ErrorMessage) {
-                        $counter = 0
                         Write-Host ""
-                        Write-Host "Failed to remove following packages due to reason '$($erroredPackage.ErrorMessage)':"
+                        $counter = 0
+                        Write-Host "- $($erroredPackage.ErrorMessage)"
                     }
                     $counter += 1
-                    Write-Host "  $counter) $($erroredPackage.PackageName)" -NoNewline
+                    Write-Host "  $counter) $($erroredPackage.PackageName)"
                     $previousErroredPackage = $erroredPackage
                 }
+                Write-Host ""
             }
         }
     } catch {


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
Makes the output of error messages (and associated package names) more concise, example:

```
Failed to remove following packages due to reason 'REASON HERE':
  1) PackageName
  2) PackageName

Failed to remove following packages due to reason 'DIFFERENT REASON HERE':
  1) PackageName
  2) PackageName
```

## Testing
Unfortunately I can't test my changes due to MicroWin requiring more free space then I have ( yes, my hard drive is full almost all the time :_) ), so hope you don't mind testing my changes locally @CodingWonders