### PR TITLE
Fix Sorting of Errored Packages by using 'Sort-Object' instead of 'IComparer' approach

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -36,30 +36,6 @@ class ErroredPackage {
     }
 }
 
-class ErroredPackageComparer : System.Collections.Generic.IComparer[ErroredPackage] {
-    [string]$PropertyName
-    [bool]$Descending = $false
-
-    ErroredPackageComparer([string]$property) {
-        $this.PropertyName = $property
-    }
-
-    ErroredPackageComparer([string]$property, [bool]$descending) {
-        $this.PropertyName = $property
-        $this.Descending = $descending
-    }
-
-    [int]Compare([ErroredPackage]$a, [ErroredPackage]$b) {
-        if ($a.$($this.PropertyName) -eq $b.$($this.PropertyName)) { $res = 0 }
-        elseif ($a.$($this.PropertyName) -lt $b.$($this.PropertyName)) { $res = -1 }
-        else { $res = 1 }
-
-        if ($this.Descending) { $res *= -1 }
-
-        return $res
-    }
-}
-
 function Get-FidoLangFromCulture {
 
     param (
@@ -223,8 +199,7 @@ function Remove-Packages {
             Write-Host "$failedCount package(s) could not be removed. Your image will still work fine, however. Below is information on what packages failed to be removed and why."
             if ($erroredPackages.Count -gt 0)
             {
-                $ErrorMessageComparer = [ErroredPackageComparer]::new("ErrorMessage")
-                $erroredPackages.Sort($ErrorMessageComparer)
+                $erroredPackages = $erroredPackages | Sort-Object -Property ErrorMessage
 
                 $previousErroredPackage = $erroredPackages[0]
                 $counter = 0


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Bug fix

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
Like my previous PR (PR #1), I can't test my changes due to limited storage, so I recommend that you test these changes before merging @CodingWonders

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
Will make it possible to Sort Errored Packages for both PS 5 & 7 Environments.